### PR TITLE
Add Exporter for db.* and http.* metrics

### DIFF
--- a/chart/fps-adot-collector/values.yaml
+++ b/chart/fps-adot-collector/values.yaml
@@ -347,7 +347,34 @@ adotCollector:
             - dimensions:  [['k8s.pod.name', 'application', 'k8s.namespace.name', 'k8s.pod.uid', 'k8s.cluster.name', 'daemon']]
               metric_name_selectors:
                 - "^process.runtime.jvm.threads.count$"
-
+        - awsemf/3:
+            namespace: "ContainerInsights/Java"
+            log_group_name: /aws/containerinsights/${EKS_CLUSTER_NAME}/Java
+            log_stream_name: "{NodeName}"
+            region: us-gov-west-1
+            resource_to_telemetry_conversion:
+              enabled: true
+            dimension_rollup_option: "NoDimensionRollup"
+            metric_declarations:
+              - dimensions:  [
+                  # Overall response time of a microservice
+                  ['k8s.cluster.name', 'k8s.namespace.name', 'application'],
+                  # Overall response time of a microservice, by status code
+                  ['k8s.cluster.name', 'k8s.namespace.name', 'application', 'http.status_code'],
+                  # Overall response time of a microservice, by operation and status code
+                  ['k8s.cluster.name', 'k8s.namespace.name', 'application', 'http.route', 'http.method', 'http.status_code'],
+                  # Response time of a specific container, by operation and status code (For investigating very specific issues)
+                  ['k8s.cluster.name', 'k8s.namespace.name', 'application', 'k8s.pod.name', 'http.route', 'http.method', 'http.status_code']
+                ]
+                metric_name_selectors:
+                  - "http.server.request.duration"
+              - dimensions: [
+                  ['k8s.cluster.name', 'k8s.namespace.name', 'application', 'pool.name', 'state'],
+                  ['k8s.cluster.name', 'k8s.namespace.name', 'application', 'k8s.pod.name', 'pool.name', 'state']
+                ]
+                metric_name_selectors:
+                  - db.client.connections
+                  
 # --- The following is example prometheusremotewrite exporter https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md
         # - prometheusremotewrite:
         #     namespace: ""


### PR DESCRIPTION
Add exporter config for db connection pool and http metrics.

NOTE: I don't have a way to actually test these changes, so treat them as just a first guess.

# Connection pool metrics

Open Telemtry defines standard metrics:
[Semantic Conventions for Database Metrics](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-metrics.md)

These are being produced by the already-pulled-in autoinstrumentation for [`hikaricp`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/hikaricp-3.0/library)

We can tell because we see logs in CloudWatch:
Log Group = `/aws/containerinsights/NGDC-FPS-EKS-cluster/Java`
```
filter OTelLib LIKE "io.opentelemetry.hikaricp"
```

# Application API metrics

Open Telemtry defines standard metrics:
[Semantic Conventions for HTTP Metrics](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md#http-server)

These are being produced by the already-pulled-in autoinstrumentation for [`tomcat`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/tomcat/tomcat-7.0/javaagent)

We can tell because we see [logs in CloudWatch](https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~unit~'seconds~editorString~'filter*20OTelLib*20LIKE*20*22io.opentelemetry.tomcat*22~queryId~'884b98dae957cab-f533c45d-4b95c32-66b45123-b8555a6184d1fe3eca8dcbf~source~(~'*2faws*2fcontainerinsights*2fNGDC-FPS-EKS-cluster*2fJava)))

Log Group = `/aws/containerinsights/NGDC-FPS-EKS-cluster/Java`
```
filter OTelLib LIKE "io.opentelemetry.tomcat"
```