### PR TITLE
Increase CPU /  Mem resources for ADOT collector

### DIFF
--- a/chart/fps-adot-collector/values.yaml
+++ b/chart/fps-adot-collector/values.yaml
@@ -61,11 +61,11 @@ adotCollector:
 # --- Resource limits and requests
     resources:
       limits:
-        cpu: "200m"
-        memory: "200Mi"
+        cpu: "500m"
+        memory: "500Mi"
       requests:
-        cpu: "200m"
-        memory: "200Mi"
+        cpu: "500m"
+        memory: "500Mi"
 # --- Tolerations to be applied on pods in this daemonset
     tolerations: []
 # --- The following volumes are preconfigured to setup the aws-otel-collector with the awscontainerinsightreceiver and awsemf exporter


### PR DESCRIPTION
We're seeing ADOT collector pods restart and 100% CPU / MEM usage, let's try roughly doubling resource requests.